### PR TITLE
Feature/#85 Implement index() method

### DIFF
--- a/src/dom/element.js
+++ b/src/dom/element.js
@@ -212,12 +212,13 @@ class Element {
   }
 
   /**
-   * Returns index of a given node
-   * @param {HTMLElement} node - HTML element
+   * Returns index of a given element
+   * @param {HTMLElement|Element} element
    * @returns {Number}
    */
-  index(node) {
+  index(element) {
     const siblings = this.children()._nodes;
+    const node = element instanceof HTMLElement ? element : element.first();
     for (let i = 0; i < siblings.length; i++) {
       if (siblings[i] === node) {
         return i;

--- a/src/dom/element.js
+++ b/src/dom/element.js
@@ -212,6 +212,21 @@ class Element {
   }
 
   /**
+   * Returns index of a given node
+   * @param {HTMLElement} node - HTML element
+   * @returns {Number}
+   */
+  index(node) {
+    const siblings = this.children()._nodes;
+    for (let i = 0; i < siblings.length; i++) {
+      if (siblings[i] === node) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /**
    * Converts Arraylike to array
    * @private
    */

--- a/src/dom/element.js
+++ b/src/dom/element.js
@@ -219,12 +219,7 @@ class Element {
   index(element) {
     const siblings = this.children()._nodes;
     const node = element instanceof HTMLElement ? element : element.first();
-    for (let i = 0; i < siblings.length; i++) {
-      if (siblings[i] === node) {
-        return i;
-      }
-    }
-    return -1;
+    return Array.prototype.indexOf.call(siblings, node);
   }
 
   /**

--- a/test/unit/features/dom/element.spec.js
+++ b/test/unit/features/dom/element.spec.js
@@ -50,6 +50,18 @@ describe('Element', () => {
       expect(Element('div').get(0).innerHTML).toEqual('First element')
       expect(Element('div').get(1).innerHTML).toEqual('Second element')
       expect(Element('div').get().length).toEqual(2);
-    })
+    });
+  });
+
+  describe('.index()', () => {
+    it('returns correct index', () => {
+      document.body.innerHTML = `<div>
+      <span id="one"></span>
+      <span id="two"></span>
+      </div>`;
+
+      expect(Element('div').index(Element('#two').first())).toEqual(1);
+      expect(Element('div').index(Element('#foo').first())).toEqual(-1);
+    });
   });
 });

--- a/test/unit/features/dom/element.spec.js
+++ b/test/unit/features/dom/element.spec.js
@@ -40,7 +40,9 @@ describe('Element', () => {
       Element('div').attr('title', null);
       expect(document.body.children[0].hasAttribute('title')).toEqual(false);
     });
+  });
 
+  describe('.get()', () => {
     it('returns correct node', () => {
       document.body.innerHTML = `
         <div>First element</div>

--- a/test/unit/features/dom/element.spec.js
+++ b/test/unit/features/dom/element.spec.js
@@ -60,8 +60,9 @@ describe('Element', () => {
       <span id="two"></span>
       </div>`;
 
+      expect(Element('div').index(Element('#one'))).toEqual(0);
       expect(Element('div').index(Element('#two').first())).toEqual(1);
-      expect(Element('div').index(Element('#foo').first())).toEqual(-1);
+      expect(Element('div').index(Element('#foo'))).toEqual(-1);
     });
   });
 });


### PR DESCRIPTION
`Index()` method returns index of the element/HTML element in the context of the parent element. (Method complementary to `eq()`)