### PR TITLE
feat(Element): Extend find() to accept > at the start of selector

### DIFF
--- a/src/dom/element.js
+++ b/src/dom/element.js
@@ -491,16 +491,22 @@ class Element {
   find(selector) {
     return this.map(function (node) {
       if (selector[0] === '>') {
-        const array =  selector.split(' ');
-        const el = new Element(node).children(array[1]);
-        if (array.length <= 2) {
-          return el;
-        } else {
-          return el.find(array.splice(2, array.length - 2).join(' '));
+        var hadId = true;
+        if (!node.id) {
+          hadId = false;
+          node.id = Math.random().toString(36).substr(2, 9);
         }
+
+        selector = '#' + node.id + selector;
       }
 
-      return new Element(selector || '*', node);
+      const result = new Element(selector || '*', node);
+
+      if (!hadId) {
+        node.id = '';
+      }
+
+      return result;
     });
   }
 

--- a/src/dom/element.js
+++ b/src/dom/element.js
@@ -490,6 +490,16 @@ class Element {
    */
   find(selector) {
     return this.map(function (node) {
+      if (selector[0] === '>') {
+        const array =  selector.split(' ');
+        const el = new Element(node).children(array[1]);
+        if (array.length <= 2) {
+          return el;
+        } else {
+          return el.find(array.splice(2, array.length - 2).join(' '));
+        }
+      }
+
       return new Element(selector || '*', node);
     });
   }

--- a/test/unit/features/dom/element.spec.js
+++ b/test/unit/features/dom/element.spec.js
@@ -42,6 +42,21 @@ describe('Element', () => {
     });
   });
 
+  describe('.find()', () => {
+    it('accepts selector starting with > operator', () => {
+      document.body.innerHTML = `
+        <div id="parent">
+          <div id="child">
+            <div id="grandchild"></div>  
+          </div>
+        </div>
+      `;
+
+      expect(Element('#parent').find('> div')).toEqual(Element('#child'));
+      expect(Element('#parent').find('> div > div')).toEqual(Element('#grandchild'));
+    })
+  });
+
   describe('.get()', () => {
     it('returns correct node', () => {
       document.body.innerHTML = `


### PR DESCRIPTION
Use element's id to call querySelectorAll - when present, otherwise add temporary one.