### PR TITLE
feat(Dynamic components): Added temporary registry type

### DIFF
--- a/examples/dynamic-cmp/index.html
+++ b/examples/dynamic-cmp/index.html
@@ -40,8 +40,6 @@
           this.$emit('input.value-changed', Strudel.$('.input').first().value);
         }
       }
-      
-      Strudel.element(document).trigger('content:loaded');
     }, 1000)
   </script>
 </body>

--- a/examples/dynamic-cmp/index.html
+++ b/examples/dynamic-cmp/index.html
@@ -1,0 +1,47 @@
+<body>
+  <div class="dynamic-input-container"></div>
+
+  <script src="../../dist/strudel.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6.24.0/babel.min.js"></script>
+  <script type="text/babel" data-plugins="transform-decorators-legacy">
+    setTimeout(() => {
+      Strudel.$('.dynamic-input-container').append(Strudel.$(`
+        <p class="input-value"></p>
+        <div class="input-container">
+          <input class="input" type="text" value="test" />
+          <button class="input-set">Set Value</button>
+        </div>
+      `))
+
+      @Strudel.Component('.input-value')
+      class InputValue {
+        init() {
+          this.value = 'Start';
+
+          this.$on('input.value-changed', function (val) {
+            if (val) {
+              this.value = val;
+              this.render();
+            }
+          }.bind(this))
+
+          this.render();
+        }
+
+        render() {
+          this.$element.html(this.value);
+        }
+      }
+
+      @Strudel.Component('.input-container')
+      class InputContainer {
+        @Strudel.Evt('click .input-set')
+        setValue() {
+          this.$emit('input.value-changed', Strudel.$('.input').first().value);
+        }
+      }
+      
+      Strudel.element(document).trigger('content:loaded');
+    }, 1000)
+  </script>
+</body>

--- a/examples/dynamic/index.html
+++ b/examples/dynamic/index.html
@@ -1,5 +1,6 @@
 <body>
   <div class="dynamic-container"></div>
+  <div class="dynamic-input-container"></div>
 
   <script src="../../dist/strudel.js"></script>
   <script src="https://unpkg.com/babel-standalone@6.24.0/babel.min.js"></script>
@@ -66,5 +67,46 @@
        </div>
       `))
     }, 500);
+
+    setTimeout(() => {
+      Strudel.$('.dynamic-input-container').append(Strudel.$(`
+        <p class="input-value"></p>
+        <div class="input-container">
+          <input class="input" type="text" value="test" />
+          <button class="input-set">Set Value</button>
+        </div>
+      `))
+
+      @Strudel.Component('.input-value')
+      class InputValue {
+        init() {
+          this.value = 'Start';
+
+          this.$on('input.value-changed', function (val) {
+            if (val) {
+              this.value = val;
+              this.render();
+            }
+          }.bind(this))
+
+          this.render();
+        }
+
+        render() {
+          this.$element.html(this.value);
+        }
+      }
+
+      @Strudel.Component('.input-container')
+      class InputContainer {
+        @Strudel.Evt('click .input-set')
+        setValue() {
+          this.$emit('input.value-changed', Strudel.$('.input').first().value);
+        }
+      }
+
+      Strudel.element(document).trigger('content:loaded');
+    }, 1000)
+
   </script>
 </body>

--- a/examples/dynamic/index.html
+++ b/examples/dynamic/index.html
@@ -55,8 +55,6 @@
       }
     }
 
-    Strudel.element(document).trigger('content:loaded');
-
     setTimeout(() => {
       Strudel.$('.dynamic-container').append(Strudel.$(`
        <div class="count" data-start="100"></div>

--- a/examples/events/index.html
+++ b/examples/events/index.html
@@ -43,7 +43,5 @@
         this.$emit('counter.decrement');
       }
     }
-
-    Strudel.element(document).trigger('content:loaded');
   </script>
 </body>

--- a/examples/interactive/index.html
+++ b/examples/interactive/index.html
@@ -20,7 +20,5 @@
     	this.$element.html(this.$data.message);
     }
   }
-
-  Strudel.element(document).trigger('content:loaded');
 </script>
 </body>

--- a/examples/mixin/index.html
+++ b/examples/mixin/index.html
@@ -36,7 +36,5 @@
       `);
     }
   }
-
-  Strudel.element(document).trigger('content:loaded');
 </script>
 </body>

--- a/examples/simple/index.html
+++ b/examples/simple/index.html
@@ -11,7 +11,5 @@
         this.$element.html(`Greetings: ${this.$data.msg}!`);
       }
     }
-
-    Strudel.element(document).trigger('content:loaded');
   </script>
 </body>

--- a/examples/static/index.html
+++ b/examples/static/index.html
@@ -1,6 +1,12 @@
 <body>
-  <div class="dynamic-container"></div>
-  <div class="dynamic-input-container"></div>
+  <div class="dynamic-container">
+    <div class="count" data-start="100"></div>
+    <div class="count-control">
+     <button class="control-increment">+1</button>
+     <button class="control-decrement">-1</button>
+     <button class="control-remove">Remove</button>
+    </div>
+  </div>
 
   <script src="../../dist/strudel.js"></script>
   <script src="https://unpkg.com/babel-standalone@6.24.0/babel.min.js"></script>
@@ -56,16 +62,5 @@
     }
 
     Strudel.element(document).trigger('content:loaded');
-
-    setTimeout(() => {
-      Strudel.$('.dynamic-container').append(Strudel.$(`
-       <div class="count" data-start="100"></div>
-       <div class="count-control">
-        <button class="control-increment">+1</button>
-        <button class="control-decrement">-1</button>
-        <button class="control-remove">Remove</button>
-       </div>
-      `))
-    }, 500);
   </script>
 </body>

--- a/examples/static/index.html
+++ b/examples/static/index.html
@@ -60,7 +60,5 @@
         this.$emit('counter.teardown');
       }
     }
-
-    Strudel.element(document).trigger('content:loaded');
   </script>
 </body>

--- a/src/core/init.js
+++ b/src/core/init.js
@@ -71,8 +71,6 @@ const onAutoTeardownCallback = (mutation) => {
 const init = () => {
   if (/comp|inter|loaded/.test(document.readyState)) {
     setTimeout(bootstrap, 0);
-  } else {
-    channel.on('DOMContentLoaded', bootstrap);
   }
 
   mount();

--- a/src/core/linker.js
+++ b/src/core/linker.js
@@ -40,7 +40,7 @@ class Linker {
    * @param {DOMElement} container
    */
   link(container = document) {
-    this.registry.getRegisteredSelectors().forEach((selector) => {
+    this.registry.getNewlyRegisteredSelectors().forEach((selector) => {
       const elements = Array.prototype.slice.call(container.querySelectorAll(selector));
       if (container !== document && $(container).is(selector)) {
         elements.push(container);
@@ -51,6 +51,7 @@ class Linker {
           const data = element.data();
           const Instance = this.registry.getComponent(selector);
           el.__strudel__ = new Instance({ element, data });
+          this.registry.setSelectorAsRegistered(selector);
         } else {
           warn(`Trying to attach component to already initialized node, component with selector ${selector} will not be attached`);
         }

--- a/src/core/linker.js
+++ b/src/core/linker.js
@@ -46,6 +46,10 @@ class Linker {
       ? this.registry.getSelectorsFromRegistrationQueue()
       : this.registry.getRegisteredSelectors();
 
+    if (selectors.length === 0) {
+      return;
+    }
+
     selectors.forEach((selector) => {
       const elements = Array.prototype.slice.call(container.querySelectorAll(selector));
       if (container !== document && $(container).is(selector)) {

--- a/src/core/linker.js
+++ b/src/core/linker.js
@@ -40,9 +40,9 @@ class Linker {
    * @param {DOMElement} container
    */
   link(container = document) {
-    const isNewNodeAdded = (container === document);
+    const isRootNode = (container === document);
 
-    const selectors = (container === document)
+    const selectors = (isRootNode)
       ? this.registry.getSelectorsFromRegistrationQueue()
       : this.registry.getRegisteredSelectors();
 
@@ -62,7 +62,7 @@ class Linker {
         }
       });
 
-      if (isNewNodeAdded) {
+      if (isRootNode) {
         this.registry.setSelectorAsRegistered(selector);
       }
     });

--- a/src/core/linker.js
+++ b/src/core/linker.js
@@ -40,6 +40,8 @@ class Linker {
    * @param {DOMElement} container
    */
   link(container = document) {
+    const isNewNodeAdded = (container === document);
+
     const selectors = (container === document)
       ? this.registry.getSelectorsFromRegistrationQueue()
       : this.registry.getRegisteredSelectors();
@@ -60,7 +62,7 @@ class Linker {
         }
       });
 
-      if (container === document) {
+      if (isNewNodeAdded) {
         this.registry.setSelectorAsRegistered(selector);
       }
     });

--- a/src/core/linker.js
+++ b/src/core/linker.js
@@ -40,7 +40,11 @@ class Linker {
    * @param {DOMElement} container
    */
   link(container = document) {
-    this.registry.getNewlyRegisteredSelectors().forEach((selector) => {
+    const selectors = (container === document)
+      ? this.registry.getSelectorsFromRegistrationQueue()
+      : this.registry.getRegisteredSelectors();
+
+    selectors.forEach((selector) => {
       const elements = Array.prototype.slice.call(container.querySelectorAll(selector));
       if (container !== document && $(container).is(selector)) {
         elements.push(container);
@@ -51,11 +55,14 @@ class Linker {
           const data = element.data();
           const Instance = this.registry.getComponent(selector);
           el.__strudel__ = new Instance({ element, data });
-          this.registry.setSelectorAsRegistered(selector);
         } else {
           warn(`Trying to attach component to already initialized node, component with selector ${selector} will not be attached`);
         }
       });
+
+      if (container === document) {
+        this.registry.setSelectorAsRegistered(selector);
+      }
     });
   }
 }

--- a/src/core/linker.js
+++ b/src/core/linker.js
@@ -61,11 +61,11 @@ class Linker {
           warn(`Trying to attach component to already initialized node, component with selector ${selector} will not be attached`);
         }
       });
-
-      if (isRootNode) {
-        this.registry.setSelectorAsRegistered(selector);
-      }
     });
+
+    if (isRootNode) {
+      this.registry.setSelectorsAsRegistered();
+    }
   }
 }
 

--- a/src/core/registry.js
+++ b/src/core/registry.js
@@ -11,7 +11,7 @@ class Registry {
   constructor() {
     this._registry = {};
     this._registrationQueue = {};
-    this._isRegisterScheduled = false;
+    this._isRegistrationScheduled = false;
   }
 
   /**
@@ -69,13 +69,13 @@ class Registry {
     } else {
       this._registrationQueue[selector] = klass;
 
-      if (!this._isRegisterScheduled) {
-        this._isRegisterScheduled = true;
+      if (!this._isRegistrationScheduled) {
+        this._isRegistrationScheduled = true;
 
-        setTimeout(() => {
+        window.requestAnimationFrame(() => {
           const ev = new Event('content:loaded');
           document.dispatchEvent(ev);
-        }, 0);
+        });
       }
     }
   }

--- a/src/core/registry.js
+++ b/src/core/registry.js
@@ -62,10 +62,7 @@ class Registry {
    * @returns {Function} constructor
    */
   getComponent(selector) {
-    if (this._registrationQueue[selector]) {
-      return this._registrationQueue[selector];
-    }
-    return this._registry[selector];
+    return this._registrationQueue[selector] || this._registry[selector];
   }
 
   /**

--- a/src/core/registry.js
+++ b/src/core/registry.js
@@ -17,7 +17,16 @@ class Registry {
    * @returns {{}|*}
    */
   getData() {
-    return Object.assign(this._registry, this._registrationQueue);
+    const registryArray = [this._registry, this._registrationQueue];
+
+    const mergedRegistry = registryArray.reduce((prev, curr) => {
+      Object.keys(curr).forEach((key) => {
+        prev[key] = curr[key];
+      });
+      return prev;
+    });
+
+    return mergedRegistry;
   }
 
   /**

--- a/src/core/registry.js
+++ b/src/core/registry.js
@@ -9,15 +9,15 @@ class Registry {
    */
   constructor() {
     this._registry = {};
-    this._tempRegistry = {};
+    this._registrationQueue = {};
   }
 
   /**
-   * Retunrs all registry data
+   * Returns both permanent registry and the registration queue entires
    * @returns {{}|*}
    */
   getData() {
-    return Object.assign(this._registry, this._tempRegistry);
+    return Object.assign(this._registry, this._registrationQueue);
   }
 
   /**
@@ -33,9 +33,9 @@ class Registry {
    * Returns an Array of temporary registry entires
    * @returns {Array} registry entries
    */
-  getNewlyRegisteredSelectors() {
+  getSelectorsFromRegistrationQueue() {
     return Object
-      .keys(this._tempRegistry);
+      .keys(this._registrationQueue);
   }
 
   /**
@@ -43,8 +43,8 @@ class Registry {
    * @param {string} selector
    */
   setSelectorAsRegistered(selector) {
-    this._registry[selector] = this._tempRegistry[selector];
-    delete this._tempRegistry[selector];
+    this._registry[selector] = this._registrationQueue[selector];
+    delete this._registrationQueue[selector];
   }
 
   /**
@@ -53,7 +53,10 @@ class Registry {
    * @returns {Function} constructor
    */
   getComponent(selector) {
-    return this._tempRegistry[selector];
+    if (this._registrationQueue[selector]) {
+      return this._registrationQueue[selector];
+    }
+    return this._registry[selector];
   }
 
   /**
@@ -62,10 +65,10 @@ class Registry {
    * @param {Function} constructor
    */
   registerComponent(selector, klass) {
-    if (this._registry[selector] || this._tempRegistry[selector]) {
+    if (this._registry[selector] || this._registrationQueue[selector]) {
       warn(`Component registered under selector: ${selector} already exists.`, klass);
     } else {
-      this._tempRegistry[selector] = klass;
+      this._registrationQueue[selector] = klass;
     }
   }
 }

--- a/src/core/registry.js
+++ b/src/core/registry.js
@@ -19,14 +19,12 @@ class Registry {
   getData() {
     const registryArray = [this._registry, this._registrationQueue];
 
-    const mergedRegistry = registryArray.reduce((prev, curr) => {
+    return registryArray.reduce((prev, curr) => {
       Object.keys(curr).forEach((key) => {
         prev[key] = curr[key];
       });
       return prev;
     });
-
-    return mergedRegistry;
   }
 
   /**
@@ -51,9 +49,9 @@ class Registry {
    * Moves selected registry entry from temporary to permanent
    * @param {string} selector
    */
-  setSelectorAsRegistered(selector) {
-    this._registry[selector] = this._registrationQueue[selector];
-    delete this._registrationQueue[selector];
+  setSelectorsAsRegistered() {
+    this._registry = this._registrationQueue;
+    this._registrationQueue = {};
   }
 
   /**

--- a/src/core/registry.js
+++ b/src/core/registry.js
@@ -9,6 +9,7 @@ class Registry {
    */
   constructor() {
     this._registry = {};
+    this._tempRegistry = {};
   }
 
   /**
@@ -16,12 +17,34 @@ class Registry {
    * @returns {{}|*}
    */
   getData() {
-    return this._registry;
+    return Object.assign(this._registry, this._tempRegistry);
   }
 
+  /**
+   * Returns an Array of registry entires
+   * @returns {Array} registry entries
+   */
   getRegisteredSelectors() {
     return Object
       .keys(this._registry);
+  }
+
+  /**
+   * Returns an Array of temporary registry entires
+   * @returns {Array} registry entries
+   */
+  getNewlyRegisteredSelectors() {
+    return Object
+      .keys(this._tempRegistry);
+  }
+
+  /**
+   * Moves selected registry entry from temporary to permanent
+   * @param {string} selector
+   */
+  setSelectorAsRegistered(selector) {
+    this._registry[selector] = this._tempRegistry[selector];
+    delete this._tempRegistry[selector];
   }
 
   /**
@@ -30,19 +53,20 @@ class Registry {
    * @returns {Function} constructor
    */
   getComponent(selector) {
-    return this._registry[selector];
+    return this._tempRegistry[selector];
   }
 
   /**
    * Adds selector/constructor pair to map
    * @param {string} selector
    * @param {Function} constructor
-     */
+   */
   registerComponent(selector, klass) {
-    if (this._registry[selector]) {
+    if (this._registry[selector] || this._tempRegistry[selector]) {
       warn(`Component registered under selector: ${selector} already exists.`, klass);
+    } else {
+      this._tempRegistry[selector] = klass;
     }
-    this._registry[selector] = klass;
   }
 }
 

--- a/src/core/registry.js
+++ b/src/core/registry.js
@@ -11,6 +11,7 @@ class Registry {
   constructor() {
     this._registry = {};
     this._registrationQueue = {};
+    this._isRegisterScheduled = false;
   }
 
   /**
@@ -67,6 +68,15 @@ class Registry {
       warn(`Component registered under selector: ${selector} already exists.`, klass);
     } else {
       this._registrationQueue[selector] = klass;
+
+      if (!this._isRegisterScheduled) {
+        this._isRegisterScheduled = true;
+
+        setTimeout(() => {
+          const ev = new Event('content:loaded');
+          document.dispatchEvent(ev);
+        }, 0);
+      }
     }
   }
 }

--- a/src/core/registry.js
+++ b/src/core/registry.js
@@ -1,4 +1,5 @@
 import { warn } from '../util/error';
+import { mergeObjects } from '../util/helpers';
 
 /**
  * Simple registry for storing selector-constructor pairs
@@ -13,18 +14,11 @@ class Registry {
   }
 
   /**
-   * Returns both permanent registry and the registration queue entires
+   * Returns both permanent registry and the registration queue entires as one object
    * @returns {{}|*}
    */
   getData() {
-    const registryArray = [this._registry, this._registrationQueue];
-
-    return registryArray.reduce((prev, curr) => {
-      Object.keys(curr).forEach((key) => {
-        prev[key] = curr[key];
-      });
-      return prev;
-    });
+    return mergeObjects(this._registry, this._registrationQueue);
   }
 
   /**
@@ -46,11 +40,11 @@ class Registry {
   }
 
   /**
-   * Moves selected registry entry from temporary to permanent
+   * Moves all entries from the registration queue to permanent registry and clears queue
    * @param {string} selector
    */
   setSelectorsAsRegistered() {
-    this._registry = this._registrationQueue;
+    this._registry = mergeObjects(this._registry, this._registrationQueue);
     this._registrationQueue = {};
   }
 

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -29,3 +29,18 @@ export const mixPrototypes = (target, source) => {
     }
   });
 };
+
+/**
+ * Util used to merge two objects together
+ * @param obj
+ * @param obj
+ * @returns {{}|*}
+ */
+export const mergeObjects = (obj1, obj2) => {
+  return [obj1, obj2].reduce((prev, curr) => {
+    Object.keys(curr).forEach((key) => {
+      prev[key] = curr[key];
+    });
+    return prev;
+  });
+};

--- a/test/e2e/specs/dynamic-cmp.js
+++ b/test/e2e/specs/dynamic-cmp.js
@@ -1,5 +1,5 @@
 module.exports = {
-  dynamicComponent(browser) {
+  lazyRegistration(browser) {
     browser
       .url('http://localhost:9876/examples/dynamic-cmp')
       .waitForElementVisible('.input-container', 5000)

--- a/test/e2e/specs/dynamic-cmp.js
+++ b/test/e2e/specs/dynamic-cmp.js
@@ -1,0 +1,11 @@
+module.exports = {
+  dynamicComponent(browser) {
+    browser
+      .url('http://localhost:9876/examples/dynamic-cmp')
+      .waitForElementVisible('.input-container', 5000)
+      .assert.containsText('.input-value', 'Start')
+      .click('.input-set')
+      .assert.containsText('.input-value', 'test')
+      .end();
+  }
+};

--- a/test/e2e/specs/dynamic.js
+++ b/test/e2e/specs/dynamic.js
@@ -10,6 +10,10 @@ module.exports = {
       .assert.containsText('.count', '100')
       .click('.control-remove')
       .assert.containsText('.count', '-1')
+      .waitForElementVisible('.input-container', 5000)
+      .assert.containsText('.input-value', 'Start')
+      .click('.input-set')
+      .assert.containsText('.input-value', 'test')
       .end();
   }
 };

--- a/test/e2e/specs/static.js
+++ b/test/e2e/specs/static.js
@@ -1,7 +1,7 @@
 module.exports = {
-  dynamic(browser) {
+  static(browser) {
     browser
-      .url('http://localhost:9876/examples/dynamic')
+      .url('http://localhost:9876/examples/static')
       .waitForElementVisible('.count', 5000)
       .assert.containsText('.count', '100')
       .click('.control-increment')

--- a/test/unit/features/core/registry.spec.js
+++ b/test/unit/features/core/registry.spec.js
@@ -30,6 +30,21 @@ describe('Core Registry', () => {
     expect(registry.getRegisteredSelectors()).toContain('selector');
   });
 
+  it('properly adds multiple entries from queue to permanent registry', () => {
+    registry.registerComponent('selector', Component);
+    expect(registry.getSelectorsFromRegistrationQueue()).toContain('selector');
+
+    registry.setSelectorsAsRegistered();
+    registry.registerComponent('selector2', Component);
+    expect(registry.getRegisteredSelectors()).toContain('selector');
+    expect(registry.getSelectorsFromRegistrationQueue()).toContain('selector2');
+
+    registry.setSelectorsAsRegistered();
+    expect(registry.getRegisteredSelectors()).toContain('selector');
+    expect(registry.getRegisteredSelectors()).toContain('selector2');
+    expect(registry.getSelectorsFromRegistrationQueue().length).toEqual(0);
+  });
+
   it('warns duplicates selectors', () => {
     registry.registerComponent('selector', Component);
     registry.registerComponent('selector', Component);

--- a/test/unit/features/core/registry.spec.js
+++ b/test/unit/features/core/registry.spec.js
@@ -20,24 +20,14 @@ describe('Core Registry', () => {
     expect(registry.getSelectorsFromRegistrationQueue()).toContain('selector2');
   });
 
-  it('moves selector from temp to perm registry', () => {
+  it('moves entires from registration queue to permanent registry', () => {
     registry.registerComponent('selector', Component);
-    expect(registry.getRegisteredSelectors()).not.toContain('selector');
     expect(registry.getSelectorsFromRegistrationQueue()).toContain('selector');
+    expect(registry.getRegisteredSelectors()).not.toContain('selector');
 
-    registry.setSelectorAsRegistered('selector');
-    expect(registry.getRegisteredSelectors()).toContain('selector');
+    registry.setSelectorsAsRegistered();
     expect(registry.getSelectorsFromRegistrationQueue()).not.toContain('selector');
-  });
-
-  it('properly merges registration queue and permanent registry', () => {
-    registry.registerComponent('tempComponent', Component);
-    registry.registerComponent('permComponent', Component);
-    registry.setSelectorAsRegistered('permComponent');
-
-    expect([...Object.keys(registry.getData())].length).toEqual(2);
-    expect(registry.getRegisteredSelectors()).toContain('permComponent');
-    expect(registry.getSelectorsFromRegistrationQueue()).toContain('tempComponent');
+    expect(registry.getRegisteredSelectors()).toContain('selector');
   });
 
   it('warns duplicates selectors', () => {

--- a/test/unit/features/core/registry.spec.js
+++ b/test/unit/features/core/registry.spec.js
@@ -30,6 +30,16 @@ describe('Core Registry', () => {
     expect(registry.getSelectorsFromRegistrationQueue()).not.toContain('selector');
   });
 
+  it('properly merges registration queue and permanent registry', () => {
+    registry.registerComponent('tempComponent', Component);
+    registry.registerComponent('permComponent', Component);
+    registry.setSelectorAsRegistered('permComponent');
+
+    expect([...Object.keys(registry.getData())].length).toEqual(2);
+    expect(registry.getRegisteredSelectors()).toContain('permComponent');
+    expect(registry.getSelectorsFromRegistrationQueue()).toContain('tempComponent');
+  });
+
   it('warns duplicates selectors', () => {
     registry.registerComponent('selector', Component);
     registry.registerComponent('selector', Component);

--- a/test/unit/features/core/registry.spec.js
+++ b/test/unit/features/core/registry.spec.js
@@ -16,18 +16,18 @@ describe('Core Registry', () => {
   it('returns registered selectors', () => {
     registry.registerComponent('selector', Component);
     registry.registerComponent('selector2', Component);
-    expect(registry.getNewlyRegisteredSelectors()).toContain('selector');
-    expect(registry.getNewlyRegisteredSelectors()).toContain('selector2');
+    expect(registry.getSelectorsFromRegistrationQueue()).toContain('selector');
+    expect(registry.getSelectorsFromRegistrationQueue()).toContain('selector2');
   });
 
   it('moves selector from temp to perm registry', () => {
     registry.registerComponent('selector', Component);
     expect(registry.getRegisteredSelectors()).not.toContain('selector');
-    expect(registry.getNewlyRegisteredSelectors()).toContain('selector');
+    expect(registry.getSelectorsFromRegistrationQueue()).toContain('selector');
 
     registry.setSelectorAsRegistered('selector');
     expect(registry.getRegisteredSelectors()).toContain('selector');
-    expect(registry.getNewlyRegisteredSelectors()).not.toContain('selector');
+    expect(registry.getSelectorsFromRegistrationQueue()).not.toContain('selector');
   });
 
   it('warns duplicates selectors', () => {

--- a/test/unit/features/core/registry.spec.js
+++ b/test/unit/features/core/registry.spec.js
@@ -16,8 +16,18 @@ describe('Core Registry', () => {
   it('returns registered selectors', () => {
     registry.registerComponent('selector', Component);
     registry.registerComponent('selector2', Component);
+    expect(registry.getNewlyRegisteredSelectors()).toContain('selector');
+    expect(registry.getNewlyRegisteredSelectors()).toContain('selector2');
+  });
+
+  it('moves selector from temp to perm registry', () => {
+    registry.registerComponent('selector', Component);
+    expect(registry.getRegisteredSelectors()).not.toContain('selector');
+    expect(registry.getNewlyRegisteredSelectors()).toContain('selector');
+
+    registry.setSelectorAsRegistered('selector');
     expect(registry.getRegisteredSelectors()).toContain('selector');
-    expect(registry.getRegisteredSelectors()).toContain('selector2');
+    expect(registry.getNewlyRegisteredSelectors()).not.toContain('selector');
   });
 
   it('warns duplicates selectors', () => {

--- a/test/unit/helpers/cleanup.js
+++ b/test/unit/helpers/cleanup.js
@@ -6,5 +6,6 @@ beforeAll(() => {
 
 afterEach((done) => {
   registry._registry = {};
+  registry._tempRegistry = {};
   done();
 });

--- a/test/unit/helpers/cleanup.js
+++ b/test/unit/helpers/cleanup.js
@@ -6,6 +6,6 @@ beforeAll(() => {
 
 afterEach((done) => {
   registry._registry = {};
-  registry._tempRegistry = {};
+  registry._registrationQueue = {};
   done();
 });


### PR DESCRIPTION
Added a temporary registry, which is used in component registration process. Entires from temporary registry are moved to permanent one after a successful action. This approach eliminates the error of trying to attach component to a node that has already been initialized. 