### PR TITLE
feat(event decorator): Evt decorator now takes two params

### DIFF
--- a/examples/decorators/index.html
+++ b/examples/decorators/index.html
@@ -28,25 +28,25 @@
     class ButtonsContainer {
 
       @Debug
-      @Evt('click .button-log') 
+      @Evt('click', '.button-log') 
       buttonLog() {
         console.log('You have clicked a button.')
       }
 
       @Debug
-      @Evt('click .button-alert') 
+      @Evt('click', '.button-alert') 
       buttonAlert() {
         alert('You have clicked a button.')
       }      
       
       @Debug
-      @Evt('click .button-change') 
+      @Evt('click', '.button-change') 
       buttonChange() {
         document.querySelector('p').innerText = 'This text has been changed'
       }      
       
       @Debug
-      @Evt('click .button-remove') 
+      @Evt('click', '.button-remove') 
       buttonRemove() {
         document.querySelector('.button-remove').remove();
         this.buttonChange();

--- a/examples/dynamic-cmp/index.html
+++ b/examples/dynamic-cmp/index.html
@@ -4,6 +4,8 @@
   <script src="../../dist/strudel.js"></script>
   <script src="https://unpkg.com/babel-standalone@6.24.0/babel.min.js"></script>
   <script type="text/babel" data-plugins="transform-decorators-legacy">
+    const { Component, Evt, $ } = Strudel;
+
     setTimeout(() => {
       Strudel.$('.dynamic-input-container').append(Strudel.$(`
         <p class="input-value"></p>
@@ -13,7 +15,7 @@
         </div>
       `))
 
-      @Strudel.Component('.input-value')
+      @Component('.input-value')
       class InputValue {
         init() {
           this.value = 'Start';
@@ -33,11 +35,11 @@
         }
       }
 
-      @Strudel.Component('.input-container')
+      @Component('.input-container')
       class InputContainer {
-        @Strudel.Evt('click', '.input-set')
+        @Evt('click', '.input-set')
         setValue() {
-          this.$emit('input.value-changed', Strudel.$('.input').first().value);
+          this.$emit('input.value-changed', $('.input').first().value);
         }
       }
     }, 1000)

--- a/examples/dynamic-cmp/index.html
+++ b/examples/dynamic-cmp/index.html
@@ -35,7 +35,7 @@
 
       @Strudel.Component('.input-container')
       class InputContainer {
-        @Strudel.Evt('click .input-set')
+        @Strudel.Evt('click', '.input-set')
         setValue() {
           this.$emit('input.value-changed', Strudel.$('.input').first().value);
         }

--- a/examples/dynamic/index.html
+++ b/examples/dynamic/index.html
@@ -37,17 +37,17 @@
     
     @Component('.count-control')
     class CountControl {
-      @Evt('click .control-increment')
+      @Evt('click', '.control-increment')
       increment() {
         this.$emit('counter.increment');
       }
 
-      @Evt('click .control-decrement')
+      @Evt('click', '.control-decrement')
       decrement() {
         this.$emit('counter.decrement');
       }
 
-      @Evt('click .control-remove')
+      @Evt('click', '.control-remove')
       remove() {
         this.$element.remove();
       }

--- a/examples/events/index.html
+++ b/examples/events/index.html
@@ -35,12 +35,12 @@
 
     @Component('.count-control')
     class CountControl {
-      @Evt('click .control-increment')
+      @Evt('click', '.control-increment')
       increment() {
         this.$emit('counter.increment');
       }
 
-      @Evt('click .control-decrement')
+      @Evt('click', '.control-decrement')
       decrement() {
         this.$emit('counter.decrement');
       }

--- a/examples/interactive/index.html
+++ b/examples/interactive/index.html
@@ -10,7 +10,7 @@
 
   @Component('.clicker')
   class Clicker {
-    @Evt('click', '.clicker__btn', true)
+    @Evt('click', '.clicker__btn')
     click() {
       this.$element.append("<div class='alert' data-message='Hello'></div>")
     }

--- a/examples/interactive/index.html
+++ b/examples/interactive/index.html
@@ -10,7 +10,7 @@
 
   @Component('.clicker')
   class Clicker {
-    @Evt('click .clicker__btn', true)
+    @Evt('click', '.clicker__btn', true)
     click() {
       this.$element.append("<div class='alert' data-message='Hello'></div>")
     }

--- a/examples/simple/index.html
+++ b/examples/simple/index.html
@@ -4,7 +4,7 @@
   <script src="../../dist/strudel.js"></script>
   <script src="https://unpkg.com/babel-standalone@6.15.0/babel.min.js"></script>
   <script type="text/babel" data-plugins="transform-decorators-legacy">
-    const { Component, Evt } = Strudel;
+    const { Component } = Strudel;
 
     @Component('.greeter')
     class Greeter {

--- a/examples/static/index.html
+++ b/examples/static/index.html
@@ -11,7 +11,9 @@
   <script src="../../dist/strudel.js"></script>
   <script src="https://unpkg.com/babel-standalone@6.24.0/babel.min.js"></script>
   <script type="text/babel" data-plugins="transform-decorators-legacy">
-    @Strudel.Component('.count')
+    const { Component, Evt } = Strudel; 
+
+    @Component('.count')
     class Count {
       init() {
       	this.value = parseInt(this.$data.start, 10);
@@ -39,19 +41,19 @@
       }
     }
 
-    @Strudel.Component('.count-control')
+    @Component('.count-control')
     class CountControl {
-      @Strudel.Evt('click', '.control-increment')
+      @Evt('click', '.control-increment')
       increment() {
         this.$emit('counter.increment');
       }
 
-      @Strudel.Evt('click', '.control-decrement')
+      @Evt('click', '.control-decrement')
       decrement() {
         this.$emit('counter.decrement');
       }
 
-      @Strudel.Evt('click', '.control-remove')
+      @Evt('click', '.control-remove')
       remove() {
         this.$element.remove();
       }

--- a/examples/static/index.html
+++ b/examples/static/index.html
@@ -41,17 +41,17 @@
 
     @Strudel.Component('.count-control')
     class CountControl {
-      @Strudel.Evt('click .control-increment')
+      @Strudel.Evt('click', '.control-increment')
       increment() {
         this.$emit('counter.increment');
       }
 
-      @Strudel.Evt('click .control-decrement')
+      @Strudel.Evt('click', '.control-decrement')
       decrement() {
         this.$emit('counter.decrement');
       }
 
-      @Strudel.Evt('click .control-remove')
+      @Strudel.Evt('click', '.control-remove')
       remove() {
         this.$element.remove();
       }

--- a/examples/tabs/index.html
+++ b/examples/tabs/index.html
@@ -28,7 +28,7 @@
     	@El('.tab-pane')
     	panes
 
-    	@Evt('click .tabs-nav a')
+    	@Evt('click', '.tabs-nav a')
     	toggleTab(evt) {
     		console.log(evt);
     		const target = evt.target.getAttribute('href').substring(1);

--- a/test/unit/features/decorators/decorator-event.spec.js
+++ b/test/unit/features/decorators/decorator-event.spec.js
@@ -6,12 +6,12 @@ describe('Decorator Event', () => {
   it('attaches event', () => {
     @Component('test')
     class TestComponent {
-      @Evt('click .element1')
+      @Evt('click', '.element1')
       method() {
         return 'element1';
       }
 
-      @Evt('click .element2')
+      @Evt('click', '.element2')
       method2() {
         return 'element2';
       }

--- a/test/unit/features/decorators/decorator-event.spec.js
+++ b/test/unit/features/decorators/decorator-event.spec.js
@@ -21,19 +21,6 @@ describe('Decorator Event', () => {
     expect(Object.keys(component._events)).toEqual(["click .element1", "click .element2"]);
   });
 
-  it('prevents default', () => {
-    @Component('empty')
-    class TestComponent {
-      @Evt('click', true)
-      test() { }
-    }
-
-    const event = { preventDefault: jasmine.createSpy() }
-    const component = new TestComponent({ element });
-    component._events['click'](event);
-    expect(event.preventDefault).toHaveBeenCalled();
-  });
-
   it('fails without descriptor', () => {
     @Component('empty')
     class Empty {


### PR DESCRIPTION
PR regarding the #71 issue. I know @xolir is currently working on it, but decorators have changed recently and I just had some time to spare, so here it is. 

Currently it's possible to decorate an event in such ways:
```
@Evt('event', '.selector')
myFunc() {}
```

```
@Evt('event', '.selector', true/false)
myFunc() {}
```

```
@Evt('event', true/false)
myFunc() {}
```

Third parameter is for preventDefault. If second parameter is a boolean then it functions the same as the third parameter would normally (not as a selector).
Third example will fire the function when the specified event happens.

Prevent Default argument is always optional, no matter where it is.